### PR TITLE
docs: Add PRD and implementation plan for schema intelligence

### DIFF
--- a/docs/LSP_PLAN.md
+++ b/docs/LSP_PLAN.md
@@ -1,0 +1,346 @@
+# Duck Tape LSP — Implementation Plan
+
+**Status:** Proposed
+**Author:** design draft
+**Scope:** Add a schema-aware SQL Language Server to `dt`, driven by the
+workspace's DuckDB database and its attached (cached) connections.
+
+---
+
+## 1. Goal
+
+Give any LSP-capable editor (Neovim, VS Code, Helix, Zed, Emacs) real-time SQL
+intelligence — completion, hover, and diagnostics — for the **exact** set of
+databases a Duck Tape workspace has attached: the local workspace `dt.db` plus
+every `ATTACH`ed connection (Postgres, MySQL, SQLite, HTTPFS/S3, Parquet/CSV/JSON
+replacement scans).
+
+The differentiator is that Duck Tape already federates every engine behind a
+single embedded DuckDB instance. The language server does not need a
+per-dialect adapter — it introspects and validates against **one** DuckDB
+catalog that already contains every attached schema. The remaining work is
+LSP plumbing, a persisted **schema cache**, and safe (read-only) connection
+handling.
+
+---
+
+## 2. Why this differs from the reference (Rust) plan
+
+The uploaded `DuckDB_Neovim_LSP_Plan` describes a greenfield **Rust /
+`tower-lsp`** server with a `DatabaseAdapter` trait to reach Postgres, MySQL,
+etc. That plan is sound in isolation, but Duck Tape is a different starting
+point, and three of its assumptions invert here:
+
+| Reference plan assumption | Duck Tape reality | Consequence |
+|---|---|---|
+| New standalone Rust binary | `dt` is a Go/Cobra binary with `go-duckdb` (CGO) already linked | Ship the LSP as `dt lsp` (a subcommand), not a separate binary. No new toolchain, no CGO cross-compile pain — the engine is already in-process. |
+| Per-engine `DatabaseAdapter` (a Postgres adapter, a MySQL adapter…) | DuckDB `ATTACH` already federates Postgres/MySQL/SQLite/files into one catalog | **No adapters needed.** Introspect + validate against the single DuckDB instance; every attached engine shows up as another `catalog.schema.table`. This is a large simplification. |
+| Must design read-only locking from scratch | `connection.ConnectionConfig.ReadWriteMode()` already appends `, READ_ONLY` unless `EnableWrite` | Attachment safety is mostly solved; we only need to also open the **workspace `dt.db` itself** read-only in LSP mode. |
+| `duckdb_prepare` via raw C API | Go `database/sql` `PrepareContext` on `go-duckdb` | Same validation strategy, idiomatic Go — DuckDB's binder/catalog checks the query, so DuckDB "Friendly SQL" (`GROUP BY ALL`, `SELECT * EXCLUDE`, `FROM 'file.parquet'`, trailing commas) validates correctly with zero false positives. |
+
+We keep the reference plan's genuinely portable ideas: **read-only by default**,
+the **hybrid parser** (error-tolerant CST for half-typed input + real engine
+`prepare` for complete statements), the **lazy, thread-safe schema cache**, and
+the **extension-lifecycle watcher**.
+
+**Language decision:** stay in Go. Rewriting in Rust would fork the engine
+integration, config, and connection logic that already exist. Go startup is
+fine for a long-lived stdio server (the ~150–300 ms Node.js concern in the
+reference does not apply to a compiled Go binary that starts once and stays
+resident).
+
+---
+
+## 3. Architecture overview
+
+```
+  Editor (Neovim / VS Code / Helix …)
+        │  JSON-RPC 2.0 over stdio
+        ▼
+  dt lsp                         ← new Cobra subcommand
+        │
+        ▼
+  lsp.Server (glsp handler)
+   ├── Document store            ← didOpen/didChange text sync
+   ├── Diagnostics engine        ← splitter → PrepareContext → parse error → Diagnostic
+   ├── Completion / Hover        ← cursor context → SchemaCache lookup
+   └── schema.Cache  ◄───────────┐
+        │  reads                 │ refresh (lazy + on DDL + background)
+        ▼                        │
+  DatabaseClient (READ_ONLY)  ───┘
+   ├── workspace dt.db  (access_mode=read_only)
+   └── ATTACH <conn> ... (, READ_ONLY)   ← Postgres / MySQL / SQLite / HTTPFS
+```
+
+The `DatabaseClient` (`cmd/database.go`) and workspace/connection resolution
+(`workspace`, `connection` packages) are reused verbatim, with one new
+read-only option (§5.2).
+
+---
+
+## 4. The schema cache (the "cached schemas / dbs" core)
+
+This is the heart of the feature and the user's explicit ask.
+
+### 4.1 What is cached
+
+For the workspace DB **and every attached connection**, cache:
+
+- **Catalogs / schemas** — `information_schema.schemata`
+- **Tables & views** — `SHOW ALL TABLES` (already used by `dt context`) →
+  `database, schema, name, column_names, column_types, temporary`
+- **Columns** — from the same `SHOW ALL TABLES` payload (names + types), with
+  `information_schema.columns` as the fallback for nullability/defaults
+- **Functions / macros / UDFs** — `duckdb_functions()`
+- **Loaded extensions** — `duckdb_extensions()` (`extension_name, loaded, installed`)
+
+### 4.2 In-memory model
+
+```go
+package schema
+
+type Column struct { Name, DataType string; Nullable bool }
+type Table  struct { Catalog, Schema, Name, Type string; Columns []Column }
+type Func   struct { Name string; Params []string; ParamTypes []string; Return string }
+
+type Cache struct {
+    mu         sync.RWMutex
+    Workspace  string
+    Tables     map[string]Table   // key: catalog.schema.name (lower-cased)
+    Functions  map[string]Func
+    Extensions map[string]bool    // name -> loaded
+    BuiltAt    time.Time
+    Fingerprint string            // hash of attached connection set
+}
+```
+
+The DuckDB root connection is opened once; per-request introspection uses
+short-lived `database/sql` connections from the pooled `*sql.DB` (DuckDB is
+multi-reader-safe within one process), matching reference recommendation #3.
+
+### 4.3 Persistence — the "cached" differentiator
+
+Introspecting a **remote** Postgres/MySQL over the network on every editor
+start is slow. Duck Tape already snapshots schemas conceptually (`dt context`);
+we make it durable:
+
+- Serialize `Cache` to `~/.dt/<workspace>/.schema_cache.json` (gitignored).
+- On `dt lsp` startup: if a cache file exists **and** its `Fingerprint`
+  (hash of the sorted attached-connection set + DB mtime) matches the current
+  workspace, load it instantly and serve completions in **<10 ms** with **zero**
+  remote round-trips. Kick off a background refresh to reconcile drift.
+- If the fingerprint differs (a connection was added/removed, or `dt.db`
+  changed), rebuild.
+- Expose it as a first-class command so it's useful outside the editor too:
+  - `dt lsp cache refresh` — force a full rebuild now.
+  - `dt lsp cache show` — print the cached schema (JSON/markdown).
+  - `dt context` is refactored to **read this same cache**, so the LLM-context
+    command and the LSP share one introspection path (see §7 DRY note).
+
+### 4.4 Invalidation & refresh
+
+- **Lazy build:** first `completion`/`hover` request triggers the build if the
+  in-memory cache is empty (keeps startup instant).
+- **DDL-aware:** when the editor buffer executes/contains a completed
+  `CREATE`/`DROP`/`ALTER`/`ATTACH`/`DETACH` (detected in the diagnostics pass),
+  mark tables dirty and re-introspect the affected catalog.
+- **Extension watcher:** a background goroutine polls `duckdb_extensions()` on an
+  interval; when an extension flips `loaded=false → true` (e.g. `spatial`, `fts`,
+  `httpfs` autoloaded on first use), fetch its new `duckdb_functions()` rows and
+  merge them so completion/signature help work without hardcoding.
+- **Config change:** `workspace/didChangeConfiguration` (switching workspace or
+  DB target at runtime) closes connections, clears the cache, reconnects.
+
+---
+
+## 5. Connection & locking strategy
+
+### 5.1 Attachments — already safe
+
+Attached connections go through the existing boot query in
+`cmd/database.go:115`, which uses `attachment.ReadWriteMode()` →
+`, READ_ONLY` by default. The LSP inherits this untouched. For attached
+SQLite/MySQL we additionally pass the reference plan's anti-starvation options
+inside `ATTACH` (`META_JOURNAL_MODE 'WAL'`, `META_BUSY_TIMEOUT 500`) so the
+server never blocks an external pipeline.
+
+### 5.2 The workspace `dt.db` — one change required
+
+Today `InitDatabaseClient` opens the workspace DB read-write
+(`<path>?threads=N`). A running `dt query` or app holding a read-write handle to
+the same file would lock-conflict with the LSP. Fix:
+
+- Add `WithReadOnly(bool)` to `DatabaseClient` and, in LSP mode, build the
+  connString as `<path>?threads=N&access_mode=read_only`.
+- `:memory:` targets cannot be read-only → force read-write (they are
+  process-isolated, so no lock risk), mirroring the reference plan's in-memory
+  rule.
+
+| Target | LSP open mode | Lock risk |
+|---|---|---|
+| Workspace `dt.db` (file) | `access_mode=read_only` | none (multi-reader) |
+| `:memory:` | read-write | none (process-local) |
+| Attached Postgres/MySQL/SQLite | `, READ_ONLY` (+ WAL/busy_timeout) | none |
+
+---
+
+## 6. Parser & diagnostics (hybrid model)
+
+Mirror the reference plan, adapted to Go:
+
+1. **Statement splitter** — a small scope-tracking tokenizer (parens, quotes,
+   `$$` blocks, `;`) isolates the statement under the cursor so one malformed
+   query doesn't poison diagnostics for the rest of the buffer.
+2. **Complete statement → validate on the real engine.** Run
+   `db.PrepareContext(ctx, stmt)` on the read-only DuckDB connection (never
+   execute — prepare only). DuckDB's binder resolves catalog/columns and accepts
+   Friendly SQL, so diagnostics are true positives.
+3. **Prepare error → LSP Diagnostic.** Parse `go-duckdb`'s error string for
+   line/column. DuckDB emits `LINE n:` and a caret (`^`) offset; extract them
+   with a regex (e.g. the reference's
+   `Parser\s+Error:.*?at or near "…" LINE (\d+)`), plus binder-error variants
+   ("Catalog Error", "Binder Error"). Map to a `protocol.Diagnostic` range and
+   `publishDiagnostics`.
+4. **Incomplete statement → don't error; complete instead.** While typing,
+   `prepare` will fail continuously — that's expected and must **not** surface as
+   a diagnostic. For these we need only cursor context for completion (§6.1).
+
+### 6.1 Completion context — phased
+
+- **Phase A (MVP, no tree-sitter):** lightweight lexer + clause heuristics.
+  Detect whether the cursor is after `FROM`/`JOIN` (→ suggest tables), inside a
+  `SELECT`/`WHERE`/`ON` projection (→ columns), or after `alias.` (→ that table's
+  columns). Resolve aliases by scanning the statement's `FROM … AS x` bindings.
+  This covers ~80% of value with no new dependency.
+- **Phase B (richer):** add `tree-sitter-sql` via `github.com/smacker/go-tree-sitter`
+  for an error-tolerant CST, enabling precise node-context scoring
+  (`projection_list` vs `from_clause` vs `where_clause`) and the reference plan's
+  relevance-weighted ranking (alias-matched columns boosted to the top).
+
+### 6.2 Hover & signature help
+
+- Hover over a table → columns + types from the cache; over a column → its type
+  and owning table; over a function → signature from `duckdb_functions()`.
+- Signature help inside `func(` → parameter list from the cached `Func`.
+
+---
+
+## 7. Code layout & reuse
+
+New package `lsp/` plus a shared `schema/` package extracted from existing code:
+
+```
+cmd/lsp.go                 # `dt lsp` + `dt lsp cache {refresh,show}` Cobra commands
+lsp/server.go              # glsp handler wiring, initialize/shutdown, capabilities
+lsp/document.go            # text document sync + in-memory buffer store
+lsp/diagnostics.go         # splitter → prepare → error-parse → publishDiagnostics
+lsp/completion.go          # completion provider (Phase A heuristics, later CST)
+lsp/hover.go               # hover + signatureHelp
+lsp/splitter.go            # statement splitter / scope tracker
+schema/cache.go            # Cache type, persistence (load/save/fingerprint)
+schema/introspect.go       # introspection queries (moved from cmd/context.go)
+```
+
+**DRY refactor:** `getSchemaMarkdown`, `getTableNames`, and the `SHOW ALL TABLES`
+logic currently living in `cmd/context.go` move into `schema/introspect.go`.
+Both `dt context` and `dt lsp` then consume one introspection + cache path.
+(This also lets `dt context` benefit from the persisted cache for instant LLM
+context on slow remote DBs.)
+
+**Client library:** recommend `github.com/tliron/glsp` (batteries-included
+Go LSP framework: JSON-RPC, stdio transport, `protocol_3_16` types, handler
+struct). Alternative: the lower-level `go.lsp.dev/protocol` + `jsonrpc2`.
+Recommendation: **glsp** for velocity; it maps cleanly onto Cobra's `Run`.
+
+**Advertised capabilities (initialize):** `textDocumentSync: Incremental`,
+`completionProvider` (triggers `.`, ` `), `hoverProvider`, `diagnosticProvider`
+(or push via `publishDiagnostics`), `signatureHelpProvider` (trigger `(`, `,`).
+
+---
+
+## 8. Configuration
+
+Extend the workspace config block (viper, `~/.dt/config.yaml`) with an optional
+`lsp` section — no breaking changes:
+
+```yaml
+dev:
+  dbLocation: /home/me/.dt/dev/dt.db
+  connections: { … existing … }
+  lsp:
+    read_only: true                     # default true; :memory: forced false
+    auto_load_extensions: [parquet, httpfs, json]
+    cache_ttl_seconds: 300              # background refresh cadence
+    connections: [my_pg, my_sqlite]     # which attachments to expose (default: all)
+```
+
+Runtime switching (the reference plan's `DuckDbSwitchTarget`) is handled via
+`workspace/didChangeConfiguration`: the server tears down connections, clears
+the cache, and rebinds to the new workspace/DB.
+
+---
+
+## 9. Editor integration
+
+Because it's a standard stdio LSP, any client works by spawning `dt lsp`.
+
+- **Neovim** (0.11+ `vim.lsp.config`): register `cmd = { "dt", "lsp" }`,
+  `filetypes = { "sql" }`, `root_dir` markers `{ ".git", "config.yaml" }`, plus a
+  `:DtSwitchWorkspace` user command that sends `didChangeConfiguration`. (Adapt
+  the Lua from the reference plan; swap the binary for `dt lsp` and drop the
+  client-side `.sqllsrc` parsing since Duck Tape already owns config discovery.)
+- **VS Code / Helix / Zed:** document the `dt lsp` command + `sql` filetype
+  mapping. A thin VS Code extension is a possible follow-up, not required.
+
+Ship a `docs/editors/` folder with copy-paste snippets for nvim + Helix.
+
+---
+
+## 10. Phased roadmap
+
+| Phase | Deliverable | Reuses / adds |
+|---|---|---|
+| **0. Scaffolding** | `dt lsp` starts a glsp stdio server, completes `initialize`/`shutdown`, advertises sync capability. | new `cmd/lsp.go`, `lsp/server.go`, glsp dep |
+| **1. Read-only engine binding** | LSP opens workspace `dt.db` read-only + attachments; `WithReadOnly` option added. | `cmd/database.go` (+`WithReadOnly`), existing connection logic |
+| **2. Diagnostics loop** | Splitter + `PrepareContext` validation + error-position parsing → `publishDiagnostics`. | `lsp/splitter.go`, `lsp/diagnostics.go` |
+| **3. Schema cache + completion/hover** | `schema.Cache` (in-mem + persisted JSON + fingerprint), Phase-A completion, hover. `dt context` refactored onto shared cache. | new `schema/` pkg, refactor `cmd/context.go` |
+| **4. Extension lifecycle + CST** | `duckdb_extensions()` watcher; tree-sitter CST for precise context + relevance scoring; signature help. | background goroutine, `go-tree-sitter` |
+| **5. Polish** | Config `lsp:` block, `didChangeConfiguration` runtime switching, editor docs (nvim/Helix), tests. | config, `docs/editors/` |
+
+MVP = Phases 0–3 (validation + schema-aware completion against cached,
+read-only attached DBs). Phases 4–5 are enhancement.
+
+---
+
+## 11. Risks & open questions
+
+- **CGO / static binary:** `go-duckdb` is CGO; `dt` already ships this way via
+  goreleaser, so `dt lsp` adds no new build constraint. Confirm release matrix
+  still builds with the new packages.
+- **Remote introspection latency & auth:** first cache build against a large
+  remote Postgres can be slow and needs live credentials. Persisted cache
+  mitigates repeat cost; document that `dt lsp cache refresh` requires the
+  connection to be reachable.
+- **`SHOW ALL TABLES` scale:** on very large catalogs, page/scope introspection
+  to the connections listed in `lsp.connections` rather than all attachments.
+- **Diagnostics precision:** DuckDB error strings vary by error class; the
+  line/column parser needs a small regex suite + a fallback that highlights the
+  whole statement when position can't be extracted.
+- **Incomplete-statement noise:** ensure prepare-failures on the actively-typed
+  statement are suppressed (only complete statements produce diagnostics).
+- **Existing bug to fold in:** `connection.ConnectionConfigForm()` doesn't set
+  `EnableWrite` (noted in `PRODUCTION_READINESS.md`); since the LSP relies on
+  `ReadWriteMode()`, fix it as part of Phase 1.
+
+---
+
+## 12. Summary
+
+Duck Tape is unusually well-positioned for this feature: the embedded DuckDB
+engine already federates every supported database into one catalog, connections
+already default to read-only, and schema introspection already exists in
+`dt context`. The plan therefore ships the language server **inside** `dt` as
+`dt lsp`, reuses the connection/engine layer, and centers on a **persisted,
+fingerprinted schema cache** so the editor gets instant, schema-aware SQL
+intelligence for the workspace's cached databases — without ever locking or
+re-hammering a remote engine.

--- a/docs/PRD-schema-intelligence.md
+++ b/docs/PRD-schema-intelligence.md
@@ -1,0 +1,347 @@
+# PRD — Duck Tape Schema Intelligence
+
+**Status:** Draft for issue slicing
+**Related:** `docs/LSP_PLAN.md` (original design exploration)
+**Owner:** TBD
+**Target binary:** `dt` (no new binaries; all surfaces ship inside `dt`)
+
+---
+
+## 1. Summary
+
+Add schema-aware intelligence to Duck Tape, built as **one shared core** exposed
+through **three surfaces**:
+
+1. **Track 1 — Developer LSP** (`dt lsp`): completion, hover, diagnostics for
+   humans writing SQL in Neovim/VS Code, driven by an in-project
+   `.ducktape.yaml`.
+2. **Track 2 — Context cache + validation CLI**: a persisted schema cache and
+   new `dt validate` / `dt explain` (+ `dt describe`, `dt cache`) commands for
+   scripting and terminal work.
+3. **Track 3 — MCP server** (`dt mcp`): agent-native tools (schema, validate,
+   explain, run) over MCP, configured by the same `.ducktape.yaml`.
+
+The design principle established during scoping: **LSP is the wrong protocol for
+agents and CLI users; the capabilities under it (schema cache + non-executing
+validation) are right for all three audiences.** Build the core once; skin it
+three ways.
+
+### 1.1 Why one core, three surfaces
+
+| Capability (shared core) | Track 1 (LSP) | Track 2 (CLI) | Track 3 (MCP) |
+|---|---|---|---|
+| Project config discovery (`.ducktape.yaml`) | root_dir + settings | project context | project context |
+| Schema cache (persisted, fingerprinted) | completion/hover source | `dt context`, `dt cache` | `list_schemas`, `describe` |
+| Prepare-based validation (no execution) | diagnostics | `dt validate` | `validate` tool |
+| Explain / cost | (future codelens) | `dt explain` | `explain` tool |
+| Read-only federated engine | yes | yes | yes |
+
+---
+
+## 2. Goals & non-goals
+
+### Goals
+- A single project-local config (`.ducktape.yaml`) that all three surfaces read.
+- A persisted, fingerprinted schema cache spanning the workspace DB + all
+  attached connections (Postgres/MySQL/SQLite/HTTPFS/files).
+- Non-executing validation (`prepare`) and `EXPLAIN` exposed as first-class
+  capabilities — important for data-lake work where running to find a typo is
+  expensive.
+- Read-only-by-default connections so no surface ever locks an external engine.
+- Agent-native access via MCP so a coding agent (e.g. Claude Code) can analyze a
+  data lake with grounded schema and cheap validation.
+
+### Non-goals (this initiative)
+- Query execution UX changes beyond what validation/explain require.
+- Result visualization, notebooks, or a TUI.
+- Multi-dialect parsing engines (DuckDB `ATTACH` already federates dialects).
+- Auth/secret-manager integration beyond env-var interpolation.
+- A bespoke VS Code extension (generic LSP client config is sufficient for v1).
+
+---
+
+## 3. Personas & primary use cases
+
+- **P1 — SQL author in an editor.** Writes `.sql` files against a project's
+  attached databases; wants completion/hover/diagnostics. → Track 1.
+- **P2 — Shell/data-pipeline author.** Scripts `dt` in Makefiles/CI; wants to
+  validate a query before an expensive run and dump schema context. → Track 2.
+- **P3 — Coding agent (Claude Code).** Analyzes data-lake data via `dt` to
+  produce reports; wants grounded schema up front and cheap validation to avoid
+  scanning TB of data on a typo. → Track 3 (and Track 2 verbs via bash).
+
+---
+
+## 4. `.ducktape.yaml` — project configuration (foundational)
+
+A project-local file discovered by walking up from the working directory
+(like `.git`). It is the single source of truth for all three surfaces and
+supersedes/extends the global `~/.dt/config.yaml`.
+
+### 4.1 Discovery & precedence
+- Search order: nearest `.ducktape.yaml` walking up from cwd → stop at repo root
+  or filesystem root.
+- If found, it defines the active workspace/connections for `dt` in that tree.
+- `extends:` may reference a global workspace name to inherit its connections;
+  inline `connections:` override/augment.
+- Absent file → fall back to today's global `~/.dt` behavior (backward
+  compatible).
+
+### 4.2 Proposed schema
+```yaml
+version: 1
+workspace: analytics            # logical name; also cache namespace
+extends: dev                    # optional: inherit from global ~/.dt workspace
+
+connections:
+  - name: prod_pg
+    type: POSTGRES
+    conn_string: "${PROD_PG_URL}"   # env interpolation; never commit secrets
+    read_only: true                 # default true
+  - name: lake
+    type: HTTPFS
+    conn_string: "s3://bucket/warehouse"
+  - name: local_events
+    type: SQLITE
+    conn_string: "./data/events.db"
+
+extensions: [httpfs, parquet, json, spatial]
+
+cache:
+  path: .ducktape/cache.json      # project-local; gitignored
+  ttl_seconds: 300                # background refresh cadence
+  scope: all                      # or a list of connection names
+
+lsp:
+  connections: [prod_pg, lake]    # subset exposed to hinting (default: all)
+
+mcp:
+  enabled: true
+  tools: [list_schemas, describe, validate, explain, run]
+  run:
+    max_rows: 1000                # safety cap on the run tool
+    allow_write: false
+```
+
+### 4.3 Requirements
+- Env-var interpolation (`${VAR}`) in `conn_string`; a missing var is a clear
+  error, never a silent empty string.
+- Secrets must never be logged or written into the cache file.
+- `.ducktape/` cache dir added to `.gitignore` guidance; `.ducktape.yaml` itself
+  is safe to commit (no inline secrets expected).
+- Validation of the file with actionable error messages (unknown keys, bad
+  types) — do not silently ignore.
+
+---
+
+## 5. Shared core — packages
+
+```
+project/                # .ducktape.yaml discovery, parse, env-interp, merge with global
+schema/
+  introspect.go         # queries moved from cmd/context.go (SHOW ALL TABLES, information_schema, duckdb_functions)
+  cache.go              # Cache model, fingerprint, JSON load/save, invalidation
+engine/
+  validate.go           # PrepareContext-based validation + DuckDB error → position parser
+  explain.go            # EXPLAIN / EXPLAIN ANALYZE (opt-in) wrappers
+cmd/database.go         # + WithReadOnly option (access_mode=read_only); :memory: forced RW
+```
+
+Track packages (`lsp/`, `mcp/`) depend only on the shared core, never on each
+other.
+
+### 5.1 Connection safety (shared)
+- Attached connections keep existing `ReadWriteMode()` → `, READ_ONLY` default;
+  add `META_JOURNAL_MODE 'WAL'`, `META_BUSY_TIMEOUT 500` for SQLite/MySQL
+  attachments to avoid starvation.
+- Workspace `dt.db` opened `access_mode=read_only` in LSP/MCP/validate paths;
+  `:memory:` forced read-write.
+- Fix the known bug: `connection.ConnectionConfigForm()` does not set
+  `EnableWrite` from the form (`PRODUCTION_READINESS.md` §1.1).
+
+---
+
+## 6. Track 1 — Developer LSP (`dt lsp`)
+
+**Depends on:** shared core (§4, §5).
+**Library:** `github.com/tliron/glsp` (stdio JSON-RPC + `protocol_3_16`).
+
+### Functional requirements
+- `dt lsp` starts a stdio LSP server; completes `initialize`/`shutdown`;
+  advertises incremental text sync, completion (triggers `.`, ` `), hover,
+  signature help (triggers `(`, `,`), and diagnostics.
+- Discovers `.ducktape.yaml` from the LSP `rootUri`; opens the federated engine
+  read-only; builds/loads the schema cache.
+- **Diagnostics:** statement splitter isolates the statement under edit →
+  `PrepareContext` on complete statements → parse DuckDB error line/col → publish
+  `Diagnostic`. Incomplete/actively-typed statements never produce errors.
+- **Completion (Phase A):** clause heuristics — tables after `FROM`/`JOIN`,
+  columns in `SELECT`/`WHERE`/`ON`, alias-resolved `alias.` → that table's
+  columns. Cache-backed; Friendly SQL respected (validation via engine, not a
+  generic grammar).
+- **Completion (Phase B, optional):** tree-sitter-sql CST
+  (`smacker/go-tree-sitter`) for precise node context + relevance scoring.
+- **Hover / signature help:** table→columns+types, column→type+owner,
+  function→signature from `duckdb_functions()`.
+- **Runtime reconfig:** `workspace/didChangeConfiguration` tears down
+  connections, clears cache, rebinds (switch workspace/target without restart).
+- **Extension watcher:** background poll of `duckdb_extensions()`; on
+  `loaded:false→true`, merge new function signatures.
+- **Editor docs:** copy-paste config for Neovim (`vim.lsp.config`, `cmd = {"dt","lsp"}`,
+  `filetypes={"sql"}`, root markers `{".ducktape.yaml",".git"}`), Helix, VS Code.
+
+### Acceptance
+- Opening a `.sql` file in a project with `.ducktape.yaml` yields table/column
+  completion from all in-scope attached DBs within ~10 ms (warm cache).
+- A query with a nonexistent column shows an inline binder-error diagnostic.
+- `SELECT * EXCLUDE (...)`, `GROUP BY ALL`, `FROM 'x.parquet'` produce **no**
+  false-positive diagnostics.
+
+---
+
+## 7. Track 2 — Context cache + validation CLI
+
+**Depends on:** shared core (§4, §5). **This track delivers the shared core’s
+CLI surface and should land first — it unblocks Tracks 1 and 3.**
+
+### Commands
+- `dt context [--json] [--connections a,b] [--tables 'glob'] [--summary]`
+  Refactored onto the schema cache; adds `--json` (structured) and scoping so an
+  agent/human can pull a slice instead of the whole lake schema. Backward
+  compatible default output.
+- `dt validate "<sql>"` (alias `dt check`) — bind/prepare only, **executes
+  nothing**; prints errors with line/col (exit non-zero on failure). Reads whole
+  buffer or `-f file.sql`.
+- `dt explain "<sql>" [--analyze]` — `EXPLAIN`; `--analyze` gated behind explicit
+  opt-in (it executes). Surface partition pruning / estimated cost.
+- `dt describe '<file-or-glob>'` — schema of ad-hoc Parquet/CSV/JSON/Iceberg via
+  `DESCRIBE SELECT * FROM '<path>'` without a full scan.
+- `dt cache {refresh|show|clear}` — manage the persisted cache;
+  `show [--json]` prints it; `refresh` forces rebuild; `clear` deletes it.
+
+### Acceptance
+- `dt validate` on a query referencing a missing column exits non-zero with a
+  useful message and does not scan data.
+- `dt context --json --connections lake` returns only the lake catalog, valid
+  JSON, from cache when fingerprint matches (no remote round-trip).
+- `dt cache refresh` rebuilds and updates fingerprint/timestamp.
+
+---
+
+## 8. Track 3 — MCP server (`dt mcp`)
+
+**Depends on:** shared core (§4, §5). **Library:** a Go MCP library — default
+`github.com/ThinkInAIXYZ/go-mcp` (the "go-mcp" named in scoping); confirm vs.
+`mark3labs/mcp-go` during A-track spike.
+
+### Functional requirements
+- `dt mcp` starts an MCP **stdio** server; loads `.ducktape.yaml` from cwd/root;
+  opens the federated engine read-only; shares the schema cache with the other
+  surfaces.
+- Tools (gated by `mcp.tools` in config):
+  - `list_schemas` — catalogs/schemas/tables (cache-backed, scopable).
+  - `describe_table` / `describe_file` — columns+types for a table or a file glob.
+  - `validate_sql` — prepare-only; returns ok/errors with positions. No execution.
+  - `explain_sql` — plan/cost.
+  - `run_query` — execute with a `max_rows` cap and `allow_write:false` default;
+    returns rows as JSON. Off unless enabled.
+- Never emit secrets in tool output or logs.
+- **Client docs:** how to register `dt mcp` in Claude Code / `claude_desktop_config`
+  (command `dt`, args `["mcp"]`), and how `.ducktape.yaml` scopes it.
+
+### Acceptance
+- A coding agent can call `list_schemas` → `validate_sql` → `run_query` to
+  produce a report over an attached lake, with `validate_sql` catching a bad
+  column before any scan, and `run_query` honoring `max_rows`.
+
+---
+
+## 9. Cross-cutting requirements
+
+- **Secrets:** env interpolation only; never log/serialize connection strings;
+  redact in errors.
+- **Build/CI:** `go-duckdb` CGO already in the release matrix; adding
+  `glsp`/`go-mcp` is pure-Go. Track 1 Phase B (`go-tree-sitter`) adds CGO — keep
+  it optional/behind a build consideration so the core stays buildable without it.
+- **Caching correctness:** fingerprint = hash(sorted in-scope connection set +
+  `dt.db` mtime + extension set). Stale-cache is the sharpest failure mode —
+  background refresh + explicit `dt cache refresh` + fingerprint mismatch rebuild.
+- **Backward compatibility:** absent `.ducktape.yaml` → current global-config
+  behavior unchanged. New commands are additive.
+- **Testing:** unit tests for splitter, error-position parser, fingerprint,
+  config discovery/interpolation; integration tests spinning a DuckDB with an
+  attached SQLite + a Parquet fixture covering validate/explain/describe/cache.
+
+---
+
+## 10. Suggested epic → issue breakdown
+
+Dependency order: **A (foundation) → B (CLI) → {C (LSP), D (MCP)} in parallel.**
+
+### Epic A — Shared foundation
+- **A1** `project` package: `.ducktape.yaml` discovery (walk-up), parse,
+  `${ENV}` interpolation, `extends` merge with global config, schema validation.
+- **A2** `WithReadOnly` on `DatabaseClient` (`access_mode=read_only`; `:memory:`
+  forced RW); SQLite/MySQL attach WAL/busy_timeout options; fix
+  `ConnectionConfigForm` `EnableWrite` bug.
+- **A3** `schema` package: move introspection out of `cmd/context.go`; define
+  `Cache` model (tables/columns/functions/extensions).
+- **A4** Cache persistence: JSON load/save, fingerprint, invalidation rules,
+  project-local `.ducktape/cache.json`.
+- **A5** `engine.Validate`: prepare-only validation + DuckDB error→position
+  parser (regex suite + whole-statement fallback).
+- **A6** `engine.Explain`: `EXPLAIN` / `EXPLAIN ANALYZE` (opt-in) wrappers.
+
+### Epic B — CLI surface (Track 2)
+- **B1** Refactor `dt context` onto cache; add `--json`, `--connections`,
+  `--tables` scoping (backward-compatible default).
+- **B2** `dt validate` / `dt check` command.
+- **B3** `dt explain` command (`--analyze` gated).
+- **B4** `dt describe '<file/glob>'` command.
+- **B5** `dt cache {refresh|show|clear}` commands.
+
+### Epic C — Developer LSP (Track 1)
+- **C1** `dt lsp` scaffold: glsp stdio, initialize/shutdown, capabilities,
+  `.ducktape.yaml` binding.
+- **C2** Document sync + statement splitter (`lsp/splitter.go`).
+- **C3** Diagnostics via `engine.Validate` → `publishDiagnostics`.
+- **C4** Completion Phase A (clause heuristics, alias resolution).
+- **C5** Hover + signature help.
+- **C6** `didChangeConfiguration` runtime reconfig + `duckdb_extensions()` watcher.
+- **C7** *(optional)* Completion Phase B: tree-sitter CST + relevance scoring.
+- **C8** Editor integration docs (`docs/editors/`: nvim, helix, vscode).
+
+### Epic D — MCP server (Track 3)
+- **D1** `dt mcp` scaffold: go-mcp stdio server + `.ducktape.yaml` load +
+  read-only engine.
+- **D2** Tools: `list_schemas`, `describe_table`, `describe_file` (cache-backed).
+- **D3** Tools: `validate_sql`, `explain_sql`.
+- **D4** Tool: `run_query` (max_rows cap, `allow_write:false` default).
+- **D5** `mcp:` config block + client setup docs (Claude Code / desktop).
+
+### Epic E — Cross-cutting
+- **E1** Secrets handling + redaction pass across all surfaces.
+- **E2** Test fixtures + integration harness (DuckDB + SQLite + Parquet).
+- **E3** CI/build review (CGO matrix; tree-sitter optionality).
+- **E4** Top-level docs: README section + `.ducktape.yaml` reference.
+
+---
+
+## 11. Open decisions
+- MCP library: `ThinkInAIXYZ/go-mcp` vs `mark3labs/mcp-go` (spike in A/D1).
+- LSP completion: ship Phase A only for v1, defer tree-sitter (C7)?
+- Cache location: always project-local `.ducktape/`, or fall back to
+  `~/.dt/<workspace>/` when no project file exists? (Proposed: project-local when
+  `.ducktape.yaml` present, else global.)
+- `run_query` in MCP: ship in v1 or start read/validate-only until safety caps
+  are proven?
+- Should `.ducktape.yaml` fully replace global workspaces long-term, or coexist?
+
+---
+
+## 12. Milestones
+- **M1 (Foundation + CLI):** Epics A + B → validation/cache/describe usable from
+  the terminal and by agents via bash. Highest leverage; unblocks everything.
+- **M2 (Agent-native):** Epic D → `dt mcp` for coding-agent workflows.
+- **M3 (Editor):** Epic C → `dt lsp` for human SQL authoring.
+- **M4 (Polish):** Epic E + LSP Phase B.


### PR DESCRIPTION
## Summary

Add comprehensive design documentation for Duck Tape's schema intelligence initiative, establishing the vision and roadmap for adding schema-aware capabilities across three surfaces: Developer LSP, CLI validation/context, and MCP server.

## Changes

- **`docs/PRD-schema-intelligence.md`** — Product Requirements Document outlining the complete initiative:
  - Single shared core exposed through three surfaces (LSP, CLI, MCP)
  - `.ducktape.yaml` project configuration format and discovery mechanism
  - Shared foundation packages (`project/`, `schema/`, `engine/`)
  - Detailed functional requirements for each track
  - Cross-cutting requirements (secrets handling, caching, backward compatibility)
  - Epic-to-issue breakdown with dependency ordering (A → B → {C, D})
  - Milestones and open decisions

- **`docs/LSP_PLAN.md`** — Detailed implementation plan for the Developer LSP track:
  - Architecture overview showing integration with existing `DatabaseClient`
  - Schema cache design (in-memory model, persistence, fingerprinting, invalidation)
  - Connection safety strategy (read-only attachments, workspace DB handling)
  - Hybrid parser approach (statement splitter + PrepareContext validation + error parsing)
  - Phased completion strategy (Phase A: clause heuristics; Phase B: tree-sitter CST)
  - Code layout and package organization
  - Configuration schema and editor integration guidance
  - Phased roadmap (5 phases from scaffolding to polish)
  - Risk assessment and open questions

## Notable Details

- Both documents emphasize **one shared core, three surfaces** — the LSP, CLI, and MCP server all consume the same schema cache and validation engine to avoid duplication
- `.ducktape.yaml` is positioned as the single source of truth for project configuration, replacing/extending the global `~/.dt/config.yaml`
- The design leverages DuckDB's existing `ATTACH` federation to avoid per-dialect adapters
- Persisted, fingerprinted schema cache enables instant (<10 ms) completion without remote round-trips
- Read-only-by-default connections prevent lock conflicts with running queries
- Backward compatibility is maintained: absent `.ducktape.yaml` falls back to current global-config behavior

These documents establish the foundation for implementing schema intelligence across Duck Tape's three primary interfaces.

https://claude.ai/code/session_01Y3Amyt9Mcq233qKUveeRYB